### PR TITLE
Dev 0.3.3

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SwiftletVersion>0.3.2</SwiftletVersion>
-    <SwiftletAssemblyVersion>0.3.2.0</SwiftletAssemblyVersion>
+    <SwiftletVersion>0.3.3</SwiftletVersion>
+    <SwiftletAssemblyVersion>0.3.3.0</SwiftletAssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/build/packaging/Publish-Target.ps1
+++ b/build/packaging/Publish-Target.ps1
@@ -574,6 +574,11 @@ $runtimeDependencies = @(
         LibraryRelativePath = "lib\netstandard2.0\HtmlAgilityPack.dll"
     },
     [pscustomobject]@{
+        ProjectPath = $pluginProjectPath
+        PackageId = "Newtonsoft.Json"
+        LibraryRelativePath = "lib\netstandard2.0\Newtonsoft.Json.dll"
+    },
+    [pscustomobject]@{
         ProjectPath = $imagingProjectPath
         PackageId = "QRCoder"
         LibraryRelativePath = "lib\net6.0\QRCoder.dll"

--- a/build/packaging/yak-manifest-template.yml
+++ b/build/packaging/yak-manifest-template.yml
@@ -35,4 +35,6 @@ keywords:
 - ai
 - llm
 - anthropic
+- guid:dab9af34-1544-4374-96b2-288f6f4788dc
 icon_url: "https://swiftlet.s3.us-east-2.amazonaws.com/Logo_32x32.png"
+platform: any

--- a/src/Swiftlet.Core/Mcp/McpClientConfigBuilder.cs
+++ b/src/Swiftlet.Core/Mcp/McpClientConfigBuilder.cs
@@ -28,6 +28,7 @@ public static class McpClientConfigBuilder
 
     public static string BuildLmStudio(string serverName, string serverUrl)
     {
+        // LM Studio follows Cursor's mcp.json shape for remote servers: url, without a type field.
         return BuildMcpServersJson(serverName, new JsonObject
         {
             ["url"] = ValidateServerUrl(serverUrl),

--- a/src/Swiftlet.Gh.Rhino8/Goo/JsonArrayGoo.cs
+++ b/src/Swiftlet.Gh.Rhino8/Goo/JsonArrayGoo.cs
@@ -1,9 +1,12 @@
 using System.Text.Json.Nodes;
+using System.Dynamic;
+using System.Linq.Expressions;
 using Grasshopper.Kernel.Types;
+using Newtonsoft.Json.Linq;
 
 namespace Swiftlet.Gh.Rhino8.Goo;
 
-public sealed class JsonArrayGoo : GH_Goo<JsonArray>
+public sealed class JsonArrayGoo : GH_Goo<JsonArray>, IDynamicMetaObjectProvider
 {
     public override bool IsValid => Value is not null;
 
@@ -23,11 +26,42 @@ public sealed class JsonArrayGoo : GH_Goo<JsonArray>
 
     public override IGH_Goo Duplicate() => new JsonArrayGoo(Value);
 
+    public override object ScriptVariable()
+    {
+        return JsonNewtonsoftInterop.ToJToken(Value);
+    }
+
+    public DynamicMetaObject GetMetaObject(Expression parameter)
+    {
+        return new JsonGooDynamicMetaObject(parameter, this);
+    }
+
     public override bool CastTo<Q>(ref Q target)
     {
-        if (typeof(Q) == typeof(JsonNodeGoo))
+        Type targetType = typeof(Q);
+
+        if (targetType == typeof(JsonNodeGoo))
         {
             object temp = new JsonNodeGoo(Value);
+            target = (Q)temp;
+            return true;
+        }
+
+        if (targetType == typeof(JArray))
+        {
+            if (JsonNewtonsoftInterop.ToJToken(Value) is JArray array)
+            {
+                object temp = array;
+                target = (Q)temp;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (targetType == typeof(JToken) || targetType == typeof(object))
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value);
             target = (Q)temp;
             return true;
         }
@@ -41,6 +75,26 @@ public sealed class JsonArrayGoo : GH_Goo<JsonArray>
         {
             Value = JsonNodeCloner.Clone(array) as JsonArray ?? new JsonArray();
             return true;
+        }
+
+        if (source is JArray jArray)
+        {
+            JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(jArray);
+            if (conversion.Node is JsonArray arrayFromNewtonsoft)
+            {
+                Value = arrayFromNewtonsoft;
+                return true;
+            }
+        }
+
+        if (source is JToken token)
+        {
+            JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(token);
+            if (conversion.Node is JsonArray arrayFromNewtonsoft)
+            {
+                Value = arrayFromNewtonsoft;
+                return true;
+            }
         }
 
         return base.CastFrom(source);

--- a/src/Swiftlet.Gh.Rhino8/Goo/JsonNodeGoo.cs
+++ b/src/Swiftlet.Gh.Rhino8/Goo/JsonNodeGoo.cs
@@ -1,9 +1,12 @@
 using System.Text.Json.Nodes;
+using System.Dynamic;
+using System.Linq.Expressions;
 using Grasshopper.Kernel.Types;
+using Newtonsoft.Json.Linq;
 
 namespace Swiftlet.Gh.Rhino8.Goo;
 
-public class JsonNodeGoo : GH_Goo<JsonNode>
+public class JsonNodeGoo : GH_Goo<JsonNode>, IDynamicMetaObjectProvider
 {
     public bool RepresentsJsonNull { get; private set; }
 
@@ -33,6 +36,16 @@ public class JsonNodeGoo : GH_Goo<JsonNode>
 
     public override IGH_Goo Duplicate() => new JsonNodeGoo(Value, RepresentsJsonNull);
 
+    public override object ScriptVariable()
+    {
+        return JsonNewtonsoftInterop.ToJToken(Value, RepresentsJsonNull);
+    }
+
+    public DynamicMetaObject GetMetaObject(Expression parameter)
+    {
+        return new JsonGooDynamicMetaObject(parameter, this);
+    }
+
     public override bool CastTo<Q>(ref Q target)
     {
         Type targetType = typeof(Q);
@@ -59,6 +72,34 @@ public class JsonNodeGoo : GH_Goo<JsonNode>
 
             target = (Q)temp;
             return RepresentsJsonNull || Value is JsonValue;
+        }
+
+        if (targetType == typeof(JObject) && Value is JsonObject)
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value);
+            target = (Q)temp;
+            return true;
+        }
+
+        if (targetType == typeof(JArray) && Value is JsonArray)
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value);
+            target = (Q)temp;
+            return true;
+        }
+
+        if (targetType == typeof(JValue) && (RepresentsJsonNull || Value is JsonValue))
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value, RepresentsJsonNull);
+            target = (Q)temp;
+            return true;
+        }
+
+        if (targetType == typeof(JToken) || targetType == typeof(object))
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value, RepresentsJsonNull);
+            target = (Q)temp;
+            return true;
         }
 
         return base.CastTo(ref target);
@@ -94,6 +135,12 @@ public class JsonNodeGoo : GH_Goo<JsonNode>
                 }
 
                 break;
+
+            case JToken token:
+                JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(token);
+                Value = conversion.Node is null ? default! : JsonNodeCloner.Clone(conversion.Node)!;
+                RepresentsJsonNull = conversion.RepresentsJsonNull;
+                return true;
         }
 
         return base.CastFrom(source);

--- a/src/Swiftlet.Gh.Rhino8/Goo/JsonObjectGoo.cs
+++ b/src/Swiftlet.Gh.Rhino8/Goo/JsonObjectGoo.cs
@@ -1,9 +1,12 @@
 using System.Text.Json.Nodes;
+using System.Dynamic;
+using System.Linq.Expressions;
 using Grasshopper.Kernel.Types;
+using Newtonsoft.Json.Linq;
 
 namespace Swiftlet.Gh.Rhino8.Goo;
 
-public sealed class JsonObjectGoo : GH_Goo<JsonObject>
+public sealed class JsonObjectGoo : GH_Goo<JsonObject>, IDynamicMetaObjectProvider
 {
     public override bool IsValid => Value is not null;
 
@@ -23,11 +26,42 @@ public sealed class JsonObjectGoo : GH_Goo<JsonObject>
 
     public override IGH_Goo Duplicate() => new JsonObjectGoo(Value);
 
+    public override object ScriptVariable()
+    {
+        return JsonNewtonsoftInterop.ToJToken(Value);
+    }
+
+    public DynamicMetaObject GetMetaObject(Expression parameter)
+    {
+        return new JsonGooDynamicMetaObject(parameter, this);
+    }
+
     public override bool CastTo<Q>(ref Q target)
     {
-        if (typeof(Q) == typeof(JsonNodeGoo))
+        Type targetType = typeof(Q);
+
+        if (targetType == typeof(JsonNodeGoo))
         {
             object temp = new JsonNodeGoo(Value);
+            target = (Q)temp;
+            return true;
+        }
+
+        if (targetType == typeof(JObject))
+        {
+            if (JsonNewtonsoftInterop.ToJToken(Value) is JObject obj)
+            {
+                object temp = obj;
+                target = (Q)temp;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (targetType == typeof(JToken) || targetType == typeof(object))
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value);
             target = (Q)temp;
             return true;
         }
@@ -41,6 +75,26 @@ public sealed class JsonObjectGoo : GH_Goo<JsonObject>
         {
             Value = JsonNodeCloner.CloneObject(obj);
             return true;
+        }
+
+        if (source is JObject jObject)
+        {
+            JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(jObject);
+            if (conversion.Node is JsonObject objectFromNewtonsoft)
+            {
+                Value = objectFromNewtonsoft;
+                return true;
+            }
+        }
+
+        if (source is JToken token)
+        {
+            JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(token);
+            if (conversion.Node is JsonObject objectFromNewtonsoft)
+            {
+                Value = objectFromNewtonsoft;
+                return true;
+            }
         }
 
         return base.CastFrom(source);

--- a/src/Swiftlet.Gh.Rhino8/Goo/JsonValueGoo.cs
+++ b/src/Swiftlet.Gh.Rhino8/Goo/JsonValueGoo.cs
@@ -1,9 +1,12 @@
 using System.Text.Json.Nodes;
+using System.Dynamic;
+using System.Linq.Expressions;
 using Grasshopper.Kernel.Types;
+using Newtonsoft.Json.Linq;
 
 namespace Swiftlet.Gh.Rhino8.Goo;
 
-public sealed class JsonValueGoo : GH_Goo<JsonValue>
+public sealed class JsonValueGoo : GH_Goo<JsonValue>, IDynamicMetaObjectProvider
 {
     public bool RepresentsJsonNull { get; private set; }
 
@@ -33,14 +36,33 @@ public sealed class JsonValueGoo : GH_Goo<JsonValue>
 
     public override IGH_Goo Duplicate() => new JsonValueGoo(Value, RepresentsJsonNull);
 
+    public override object ScriptVariable()
+    {
+        return JsonNewtonsoftInterop.ToJToken(Value, RepresentsJsonNull);
+    }
+
+    public DynamicMetaObject GetMetaObject(Expression parameter)
+    {
+        return new JsonGooDynamicMetaObject(parameter, this);
+    }
+
     public override bool CastTo<Q>(ref Q target)
     {
-        if (typeof(Q) == typeof(JsonNodeGoo))
+        Type targetType = typeof(Q);
+
+        if (targetType == typeof(JsonNodeGoo))
         {
             object temp = RepresentsJsonNull
                 ? JsonNodeGoo.CreateJsonNull()
                 : new JsonNodeGoo(Value);
 
+            target = (Q)temp;
+            return true;
+        }
+
+        if (targetType == typeof(JValue) || targetType == typeof(JToken) || targetType == typeof(object))
+        {
+            object temp = JsonNewtonsoftInterop.ToJToken(Value, RepresentsJsonNull);
             target = (Q)temp;
             return true;
         }
@@ -62,6 +84,42 @@ public sealed class JsonValueGoo : GH_Goo<JsonValue>
             if (nodeGoo.Value is JsonValue nodeGooValue)
             {
                 Value = JsonNodeCloner.Clone(nodeGooValue) as JsonValue;
+                RepresentsJsonNull = false;
+                return true;
+            }
+        }
+
+        if (source is JValue jValue)
+        {
+            JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(jValue);
+            if (conversion.RepresentsJsonNull)
+            {
+                Value = default!;
+                RepresentsJsonNull = true;
+                return true;
+            }
+
+            if (conversion.Node is JsonValue value)
+            {
+                Value = value;
+                RepresentsJsonNull = false;
+                return true;
+            }
+        }
+
+        if (source is JToken token)
+        {
+            JsonNewtonsoftInterop.JsonNodeConversion conversion = JsonNewtonsoftInterop.FromJToken(token);
+            if (conversion.RepresentsJsonNull)
+            {
+                Value = default!;
+                RepresentsJsonNull = true;
+                return true;
+            }
+
+            if (conversion.Node is JsonValue value)
+            {
+                Value = value;
                 RepresentsJsonNull = false;
                 return true;
             }

--- a/src/Swiftlet.Gh.Rhino8/JsonNewtonsoftInterop.cs
+++ b/src/Swiftlet.Gh.Rhino8/JsonNewtonsoftInterop.cs
@@ -26,7 +26,10 @@ internal static class JsonNewtonsoftInterop
             return new JsonNodeConversion(null, RepresentsJsonNull: true);
         }
 
-        return new JsonNodeConversion(JsonNode.Parse(token.ToString(Formatting.None)), RepresentsJsonNull: false);
+        JsonNode? parsed = JsonNode.Parse(token.ToString(Formatting.None));
+        return parsed is null
+            ? new JsonNodeConversion(null, RepresentsJsonNull: true)
+            : new JsonNodeConversion(parsed, RepresentsJsonNull: false);
     }
 
     public readonly record struct JsonNodeConversion(JsonNode? Node, bool RepresentsJsonNull);

--- a/src/Swiftlet.Gh.Rhino8/JsonNewtonsoftInterop.cs
+++ b/src/Swiftlet.Gh.Rhino8/JsonNewtonsoftInterop.cs
@@ -1,0 +1,58 @@
+using System.Dynamic;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Grasshopper.Kernel.Types;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Swiftlet.Gh.Rhino8;
+
+internal static class JsonNewtonsoftInterop
+{
+    public static JToken ToJToken(JsonNode? node, bool representsJsonNull = false)
+    {
+        return representsJsonNull || node is null
+            ? JValue.CreateNull()
+            : JToken.Parse(node.ToJsonString());
+    }
+
+    public static JsonNodeConversion FromJToken(JToken token)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+
+        if (token.Type is JTokenType.Null or JTokenType.Undefined)
+        {
+            return new JsonNodeConversion(null, RepresentsJsonNull: true);
+        }
+
+        return new JsonNodeConversion(JsonNode.Parse(token.ToString(Formatting.None)), RepresentsJsonNull: false);
+    }
+
+    public readonly record struct JsonNodeConversion(JsonNode? Node, bool RepresentsJsonNull);
+}
+
+internal sealed class JsonGooDynamicMetaObject : DynamicMetaObject
+{
+    public JsonGooDynamicMetaObject(Expression expression, object value)
+        : base(expression, BindingRestrictions.Empty, value)
+    {
+    }
+
+    public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+    {
+        if (binder.Name == nameof(GH_Goo<object>.Value))
+        {
+            MethodInfo scriptVariableMethod = LimitType.GetMethod(nameof(IGH_Goo.ScriptVariable), Type.EmptyTypes)
+                ?? throw new MissingMethodException(LimitType.FullName, nameof(IGH_Goo.ScriptVariable));
+
+            Expression self = Expression.Convert(Expression, LimitType);
+            Expression scriptVariable = Expression.Call(self, scriptVariableMethod);
+            return new DynamicMetaObject(
+                Expression.Convert(scriptVariable, typeof(object)),
+                BindingRestrictions.GetTypeRestriction(Expression, LimitType));
+        }
+
+        return binder.FallbackGetMember(this);
+    }
+}

--- a/src/Swiftlet.Gh.Rhino8/Swiftlet.Gh.Rhino8.csproj
+++ b/src/Swiftlet.Gh.Rhino8/Swiftlet.Gh.Rhino8.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.43" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RhinoCommon" Version="$(RhinoCommonPackageVersion)">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/tests/Swiftlet.Core.Tests/Program.cs
+++ b/tests/Swiftlet.Core.Tests/Program.cs
@@ -504,44 +504,89 @@ internal static class TestRunner
             "Swiftlet",
             new BridgeLaunchCommand("dotnet", ["/tmp/SwiftletBridge.dll", "http://localhost:3001/mcp/"]));
 
-        Assert.Contains("\"type\": \"stdio\"", json);
-        Assert.Contains("\"command\": \"dotnet\"", json);
-        Assert.Contains("\"Swiftlet\"", json);
-        Assert.Contains("\"http://localhost:3001/mcp/\"", json);
+        AssertJsonEqual(
+            new JsonObject
+            {
+                ["mcpServers"] = new JsonObject
+                {
+                    ["Swiftlet"] = new JsonObject
+                    {
+                        ["type"] = "stdio",
+                        ["command"] = "dotnet",
+                        ["args"] = new JsonArray
+                        {
+                            "/tmp/SwiftletBridge.dll",
+                            "http://localhost:3001/mcp/",
+                        },
+                    },
+                },
+            },
+            ParseJsonObject(json));
     }
 
     private static void McpClientConfigBuilderSerializesLmStudioConfig()
     {
         string json = McpClientConfigBuilder.BuildLmStudio("Swiftlet", "http://localhost:3001/mcp/");
 
-        Assert.Contains("\"mcpServers\"", json);
-        Assert.Contains("\"url\": \"http://localhost:3001/mcp/\"", json);
+        AssertJsonEqual(
+            new JsonObject
+            {
+                ["mcpServers"] = new JsonObject
+                {
+                    ["Swiftlet"] = new JsonObject
+                    {
+                        ["url"] = "http://localhost:3001/mcp/",
+                    },
+                },
+            },
+            ParseJsonObject(json));
     }
 
     private static void McpClientConfigBuilderSerializesVsCodeConfig()
     {
         string json = McpClientConfigBuilder.BuildVsCode("Swiftlet", "http://localhost:3001/mcp/");
 
-        Assert.Contains("\"servers\"", json);
-        Assert.Contains("\"type\": \"http\"", json);
-        Assert.Contains("\"url\": \"http://localhost:3001/mcp/\"", json);
+        AssertJsonEqual(
+            new JsonObject
+            {
+                ["servers"] = new JsonObject
+                {
+                    ["Swiftlet"] = new JsonObject
+                    {
+                        ["type"] = "http",
+                        ["url"] = "http://localhost:3001/mcp/",
+                    },
+                },
+            },
+            ParseJsonObject(json));
     }
 
     private static void McpClientConfigBuilderSerializesClaudeCodeConfig()
     {
         string json = McpClientConfigBuilder.BuildClaudeCode("Swiftlet", "http://localhost:3001/mcp/");
 
-        Assert.Contains("\"mcpServers\"", json);
-        Assert.Contains("\"type\": \"http\"", json);
-        Assert.Contains("\"url\": \"http://localhost:3001/mcp/\"", json);
+        AssertJsonEqual(
+            new JsonObject
+            {
+                ["mcpServers"] = new JsonObject
+                {
+                    ["Swiftlet"] = new JsonObject
+                    {
+                        ["type"] = "http",
+                        ["url"] = "http://localhost:3001/mcp/",
+                    },
+                },
+            },
+            ParseJsonObject(json));
     }
 
     private static void McpClientConfigBuilderSerializesCodexConfig()
     {
         string toml = McpClientConfigBuilder.BuildCodex("Swiftlet", "http://localhost:3001/mcp/");
 
-        Assert.Contains("[mcp_servers.\"Swiftlet\"]", toml);
-        Assert.Contains("url = \"http://localhost:3001/mcp/\"", toml);
+        Assert.Equal(
+            "[mcp_servers.\"Swiftlet\"]\nurl = \"http://localhost:3001/mcp/\"\n",
+            toml.ReplaceLineEndings("\n"));
     }
 
     private static void McpToolDefinitionBuildsInputSchema()

--- a/tests/Swiftlet.Integration.Tests/Program.cs
+++ b/tests/Swiftlet.Integration.Tests/Program.cs
@@ -4,6 +4,9 @@ using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Nodes;
+using Grasshopper.Kernel.Types;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Swiftlet.Core.Auth;
 using Swiftlet.Core.Mcp;
 using Swiftlet.Gh.Rhino8;
@@ -30,6 +33,8 @@ internal static class IntegrationTestRunner
             ("Utility URL encoding preserves form encoding semantics", UtilityUrlEncodingProducesExpectedOutputAsync),
             ("Archived legacy components keep 0.2.0 GUIDs hidden", ArchivedLegacyComponentsKeep020GuidsHiddenAsync),
             ("JSON null goos remain valid and preserve null semantics", JsonNullGoosPreserveNullSemanticsAsync),
+            ("JSON goos cast to Newtonsoft tokens for external serializers", JsonGoosCastToNewtonsoftTokensForExternalSerializersAsync),
+            ("JSON goos cast from Newtonsoft tokens for legacy interop", JsonGoosCastFromNewtonsoftTokensAsync),
             ("Headless host services require manual browser and clipboard actions", HeadlessServicesRequireManualActionsAsync),
             ("Desktop host workflow exposes desktop capabilities", DesktopWorkflowExposesCapabilitiesAsync),
             ("Modern OAuth authorization flow tracks state through callback completion", OAuthAuthorizationFlowTracksStateAsync),
@@ -258,6 +263,78 @@ internal static class IntegrationTestRunner
         Assert.True(duplicatedNode.RepresentsJsonNull);
         Assert.Null(duplicatedValue.Value);
         Assert.Null(duplicatedNode.Value);
+        return Task.CompletedTask;
+    }
+
+    private static Task JsonGoosCastToNewtonsoftTokensForExternalSerializersAsync()
+    {
+        JsonObjectGoo goo = new(CreateBoundaryFixture());
+
+        Assert.True(CastTo(goo, typeof(object), out object? externalObject));
+        Assert.True(externalObject is JObject);
+        Assert.Equal(
+            """{"boundary":{"points":[0,0,24,0,24,12,0,12,0,0],"mask":"XY"}}""",
+            JsonConvert.SerializeObject(externalObject, Formatting.None));
+        Assert.Equal(
+            """{"boundary":{"points":[0,0,24,0,24,12,0,12,0,0],"mask":"XY"}}""",
+            JsonConvert.SerializeObject(goo.ScriptVariable(), Formatting.None));
+        dynamic dynamicObjectGoo = goo;
+        Assert.Equal(
+            """{"boundary":{"points":[0,0,24,0,24,12,0,12,0,0],"mask":"XY"}}""",
+            JsonConvert.SerializeObject(dynamicObjectGoo.Value, Formatting.None));
+
+        Assert.True(CastTo(goo, typeof(JToken), out object? externalToken));
+        Assert.True(externalToken is JObject);
+        Assert.Equal(
+            """{"boundary":{"points":[0,0,24,0,24,12,0,12,0,0],"mask":"XY"}}""",
+            ((JToken)externalToken!).ToString(Formatting.None));
+        AssertDoesNotCastToRawJsonString(
+            goo,
+            """{"boundary":{"points":[0,0,24,0,24,12,0,12,0,0],"mask":"XY"}}""");
+
+        var arrayGoo = new JsonArrayGoo((JsonArray)CreateBoundaryFixture()["boundary"]!["points"]!);
+        Assert.True(CastTo(arrayGoo, typeof(object), out object? externalArray));
+        Assert.True(externalArray is JArray);
+        Assert.Equal("[0,0,24,0,24,12,0,12,0,0]", JsonConvert.SerializeObject(externalArray, Formatting.None));
+        Assert.Equal("[0,0,24,0,24,12,0,12,0,0]", JsonConvert.SerializeObject(arrayGoo.ScriptVariable(), Formatting.None));
+        dynamic dynamicArrayGoo = arrayGoo;
+        Assert.Equal("[0,0,24,0,24,12,0,12,0,0]", JsonConvert.SerializeObject(dynamicArrayGoo.Value, Formatting.None));
+        AssertDoesNotCastToRawJsonString(arrayGoo, "[0,0,24,0,24,12,0,12,0,0]");
+
+        JsonNodeGoo nullGoo = JsonNodeGoo.CreateJsonNull();
+        Assert.True(CastTo(nullGoo, typeof(object), out object? externalNull));
+        Assert.True(externalNull is JValue);
+        Assert.Equal("null", JsonConvert.SerializeObject(externalNull, Formatting.None));
+        Assert.Equal("null", JsonConvert.SerializeObject(nullGoo.ScriptVariable(), Formatting.None));
+        dynamic dynamicNullGoo = nullGoo;
+        Assert.Equal("null", JsonConvert.SerializeObject(dynamicNullGoo.Value, Formatting.None));
+        AssertDoesNotCastToRawJsonString(nullGoo, "null");
+
+        return Task.CompletedTask;
+    }
+
+    private static Task JsonGoosCastFromNewtonsoftTokensAsync()
+    {
+        var objectGoo = new JsonObjectGoo();
+        Assert.True(objectGoo.CastFrom(JObject.Parse("""{"boundary":{"points":[0,0],"mask":"XY"}}""")));
+        Assert.Equal("""{"boundary":{"points":[0,0],"mask":"XY"}}""", objectGoo.Value!.ToJsonString());
+
+        var arrayGoo = new JsonArrayGoo();
+        Assert.True(arrayGoo.CastFrom(JArray.Parse("[0,24,12]")));
+        Assert.Equal("[0,24,12]", arrayGoo.Value!.ToJsonString());
+
+        var nodeGoo = new JsonNodeGoo();
+        Assert.True(nodeGoo.CastFrom(JToken.Parse("""{"ok":true}""")));
+        Assert.Equal("""{"ok":true}""", nodeGoo.Value!.ToJsonString());
+
+        var valueGoo = new JsonValueGoo();
+        Assert.True(valueGoo.CastFrom(new JValue("XY")));
+        Assert.Equal("\"XY\"", valueGoo.Value!.ToJsonString());
+
+        Assert.True(valueGoo.CastFrom(JValue.CreateNull()));
+        Assert.True(valueGoo.RepresentsJsonNull);
+        Assert.Null(valueGoo.Value);
+
         return Task.CompletedTask;
     }
 
@@ -1017,9 +1094,9 @@ internal static class IntegrationTestRunner
                ?? throw new InvalidOperationException($"Unable to find shell type '{fullName}'.");
     }
 
-    private static bool CastTo(BitmapGoo goo, Type targetType, out object? target)
+    private static bool CastTo(IGH_Goo goo, Type targetType, out object? target)
     {
-        MethodInfo castMethod = typeof(BitmapGoo)
+        MethodInfo castMethod = goo.GetType()
             .GetMethods()
             .Single(static method => method.Name == nameof(BitmapGoo.CastTo) && method.IsGenericMethodDefinition);
 
@@ -1027,6 +1104,33 @@ internal static class IntegrationTestRunner
         bool result = (bool)castMethod.MakeGenericMethod(targetType).Invoke(goo, args)!;
         target = args[0];
         return result;
+    }
+
+    private static void AssertDoesNotCastToRawJsonString(IGH_Goo goo, string rawJson)
+    {
+        bool castsToRawJsonString = CastTo(goo, typeof(string), out object? target)
+            && target is string text
+            && string.Equals(text, rawJson, StringComparison.Ordinal);
+
+        Assert.False(castsToRawJsonString, "JSON goo should not cast directly to raw JSON text.");
+    }
+
+    private static JsonObject CreateBoundaryFixture()
+    {
+        var points = new JsonArray();
+        foreach (int value in new[] { 0, 0, 24, 0, 24, 12, 0, 12, 0, 0 })
+        {
+            points.Add(value);
+        }
+
+        return new JsonObject
+        {
+            ["boundary"] = new JsonObject
+            {
+                ["points"] = points,
+                ["mask"] = "XY",
+            },
+        };
     }
 
     private static string NormalizePathForTest(string path, bool isWindows)


### PR DESCRIPTION
Compatibility improvements with JSwan

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Newtonsoft.Json interoperability to all four Grasshopper Goo types (`JsonObjectGoo`, `JsonArrayGoo`, `JsonValueGoo`, `JsonNodeGoo`) so that Swiftlet JSON outputs can be consumed directly by components that expect Newtonsoft `JToken` values — most notably JSwan.

- A new `JsonNewtonsoftInterop` class handles round-trip conversion between `System.Text.Json.Nodes` and Newtonsoft `JToken` via JSON serialization, and a `JsonGooDynamicMetaObject` rewrites dynamic `.Value` member access to call `ScriptVariable()`, returning a `JToken` instead of the underlying `JsonNode`.
- All four Goo types now implement `IDynamicMetaObjectProvider`, override `ScriptVariable()` to return the equivalent Newtonsoft token, and add `CastTo`/`CastFrom` branches for `JObject`, `JArray`, `JValue`, `JToken`, and `object` target types.
- Integration tests cover both directions of the cast for all Goo types, including null semantics and the `dynamic.Value` path; core tests are upgraded from substring `Contains` checks to structural JSON equality assertions.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the interop logic is well-encapsulated and the two new integration tests exercise all four Goo types in both cast directions including null semantics.

The conversion paths are straightforward (serialize to JSON string, re-parse), the DynamicMetaObject restriction is correctly scoped per concrete type, and the test coverage is thorough. The only new observations are redundant fall-through paths in CastFrom that are harmless in practice.

The CastFrom implementations in JsonObjectGoo, JsonArrayGoo, and JsonValueGoo all have the redundant JToken fall-through pattern worth tidying up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/Swiftlet.Gh.Rhino8/JsonNewtonsoftInterop.cs | New file providing bidirectional conversion between System.Text.Json.Nodes and Newtonsoft JToken, plus a DynamicMetaObject that rewrites .Value member access to call ScriptVariable(). The JRaw/null edge case in FromJToken was flagged in a prior thread. |
| src/Swiftlet.Gh.Rhino8/Goo/JsonObjectGoo.cs | Adds IDynamicMetaObjectProvider, ScriptVariable() returning JObject, and bidirectional JToken cast support. The JToken fallback block is redundant for JObject sources. |
| src/Swiftlet.Gh.Rhino8/Goo/JsonArrayGoo.cs | Adds IDynamicMetaObjectProvider, ScriptVariable() returning JArray, and bidirectional JToken cast support; contains the same redundant JToken fallback block pattern as JsonObjectGoo. |
| src/Swiftlet.Gh.Rhino8/Goo/JsonValueGoo.cs | Adds IDynamicMetaObjectProvider, ScriptVariable() returning JValue/JValue.CreateNull(), and bidirectional JToken cast support; the JValue-specific block in CastFrom silently falls through to the JToken block on the rare path where neither null nor JsonValue is matched. |
| src/Swiftlet.Gh.Rhino8/Goo/JsonNodeGoo.cs | Adds IDynamicMetaObjectProvider, ScriptVariable() returning a JToken, and a JToken case in CastFrom that always returns true (the null-inconsistency edge case was flagged in a prior thread). |
| tests/Swiftlet.Integration.Tests/Program.cs | Adds two well-structured integration tests covering round-trip cast to/from Newtonsoft tokens for all four Goo types, including null semantics and the dynamic .Value accessor path. |
| tests/Swiftlet.Core.Tests/Program.cs | Upgrades McpClientConfigBuilder tests from substring Contains assertions to full structural JSON equality, improving assertion quality. |
| build/packaging/Publish-Target.ps1 | Adds Newtonsoft.Json.dll to the Yak runtime dependency list so it is bundled alongside the plugin assembly. |
| build/packaging/yak-manifest-template.yml | Adds the JSwan package GUID as a Yak keyword (cross-package compatibility declaration) and sets platform: any. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GH Component Output\nJsonObjectGoo / JsonArrayGoo\nJsonValueGoo / JsonNodeGoo] --> B{Target context?}

    B -->|Grasshopper wire\nCastTo JsonNodeGoo| C[JsonNodeGoo\nSystem.Text.Json.Nodes]
    B -->|CastTo JObject / JArray / JValue| D[JsonNewtonsoftInterop.ToJToken\nnode.ToJsonString → JToken.Parse]
    B -->|CastTo object or ScriptVariable| D
    B -->|dynamic .Value| E[JsonGooDynamicMetaObject\nBindGetMember → ScriptVariable]

    D --> F{Token type}
    F -->|JObject| G[Newtonsoft JObject]
    F -->|JArray| H[Newtonsoft JArray]
    F -->|null / RepresentsJsonNull| I[JValue.CreateNull]
    F -->|scalar| J[Newtonsoft JValue]

    E --> D

    K[External JToken\ne.g. from JSwan] --> L[CastFrom]
    L --> M[JsonNewtonsoftInterop.FromJToken\nJToken.ToString → JsonNode.Parse]
    M --> N[System.Text.Json.Nodes\nstored in Goo.Value]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[GH Component Output\nJsonObjectGoo / JsonArrayGoo\nJsonValueGoo / JsonNodeGoo] --> B{Target context?}

    B -->|Grasshopper wire\nCastTo JsonNodeGoo| C[JsonNodeGoo\nSystem.Text.Json.Nodes]
    B -->|CastTo JObject / JArray / JValue| D[JsonNewtonsoftInterop.ToJToken\nnode.ToJsonString → JToken.Parse]
    B -->|CastTo object or ScriptVariable| D
    B -->|dynamic .Value| E[JsonGooDynamicMetaObject\nBindGetMember → ScriptVariable]

    D --> F{Token type}
    F -->|JObject| G[Newtonsoft JObject]
    F -->|JArray| H[Newtonsoft JArray]
    F -->|null / RepresentsJsonNull| I[JValue.CreateNull]
    F -->|scalar| J[Newtonsoft JValue]

    E --> D

    K[External JToken\ne.g. from JSwan] --> L[CastFrom]
    L --> M[JsonNewtonsoftInterop.FromJToken\nJToken.ToString → JsonNode.Parse]
    M --> N[System.Text.Json.Nodes\nstored in Goo.Value]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Update src/Swiftlet.Gh.Rhino8/JsonNewton..."](https://github.com/enmerk4r/swiftlet/commit/d61274f1139db1498a488c8746d41eb4a1d4d355) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39066937)</sub>

<!-- /greptile_comment -->